### PR TITLE
Fix get_alias crash: normalise multi-select edit-form fields

### DIFF
--- a/opnsense_py/models/base.py
+++ b/opnsense_py/models/base.py
@@ -31,12 +31,14 @@ class OPNsenseModel(BaseModel):
     def _normalize_edit_form(cls, values: Any) -> Any:
         """Normalize the edit-form response format returned by OPNsense ``get_*`` endpoints.
 
-        Edit-form responses differ from grid/search responses in two ways:
+        Edit-form responses differ from grid/search responses in several ways:
         - Dropdown/enum fields are dicts like ``{"A": {"value": "...", "selected": 1}, ...}``
           instead of plain strings.
         - Optional integer fields use ``""`` when unset instead of ``null``.
+        - Optional string fields (e.g. ``categories``) use ``[]`` when unset instead of
+          ``null`` or ``""``.
 
-        This validator handles both cases generically for all subclasses.
+        This validator handles all cases generically for all subclasses.
         """
         if not isinstance(values, dict):
             return values
@@ -47,7 +49,7 @@ class OPNsenseModel(BaseModel):
             ann = field_info.annotation
             if _is_optional(ann, int) and value == "":
                 values[field_name] = None
-            elif _is_optional(ann, str) and isinstance(value, list):
+            elif _is_optional(ann, str) and value == []:
                 values[field_name] = ""
             elif _is_optional(ann, str) and isinstance(value, dict):
                 values[field_name] = _extract_selected(value)

--- a/opnsense_py/models/base.py
+++ b/opnsense_py/models/base.py
@@ -8,11 +8,14 @@ T = TypeVar("T")
 
 
 def _extract_selected(d: dict[str, Any]) -> str | None:
-    """Return the key whose value dict has ``selected == 1``, or ``None``."""
-    for key, meta in d.items():
-        if isinstance(meta, dict) and meta.get("selected") == 1:
-            return key
-    return None
+    """Return all keys whose value dict has ``selected == 1``, joined by newline.
+
+    Single-select fields yield a bare string; multi-select fields (e.g. alias
+    ``content``) yield a newline-separated string matching the POST payload format.
+    Returns ``None`` when nothing is selected.
+    """
+    selected = [key for key, meta in d.items() if isinstance(meta, dict) and meta.get("selected") == 1]
+    return "\n".join(selected) if selected else None
 
 
 def _is_optional(annotation: Any, target: type) -> bool:

--- a/opnsense_py/models/base.py
+++ b/opnsense_py/models/base.py
@@ -47,6 +47,8 @@ class OPNsenseModel(BaseModel):
             ann = field_info.annotation
             if _is_optional(ann, int) and value == "":
                 values[field_name] = None
+            elif _is_optional(ann, str) and isinstance(value, list):
+                values[field_name] = ""
             elif _is_optional(ann, str) and isinstance(value, dict):
                 values[field_name] = _extract_selected(value)
         return values

--- a/tests/unit/modules/core/test_firewall.py
+++ b/tests/unit/modules/core/test_firewall.py
@@ -113,6 +113,75 @@ def test_categories_string_value_unchanged(model_cls: type) -> None:
     assert instance.categories == "some-uuid"
 
 
+def test_get_alias_parses_edit_form_response(
+    client: OPNsenseClient, mock_api: respx.MockRouter
+) -> None:
+    """get_alias must parse the form-data format returned by getAlias/{uuid}."""
+    mock_api.get("/api/firewall/alias/get_item/alias-uuid").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "alias": {
+                    "enabled": "1",
+                    "name": "my_alias",
+                    "type": {
+                        "host": {"value": "Host(s)", "selected": 0},
+                        "network": {"value": "Network(s)", "selected": 1},
+                        "port": {"value": "Port(s)", "selected": 0},
+                    },
+                    "proto": {
+                        "": {"value": "any", "selected": 1},
+                        "IPv4": {"value": "IPv4", "selected": 0},
+                        "IPv6": {"value": "IPv6", "selected": 0},
+                    },
+                    "interface": {
+                        "": {"value": "any", "selected": 1},
+                        "wan": {"value": "WAN", "selected": 0},
+                    },
+                    "content": {
+                        "192.168.1.0/24": {"value": "192.168.1.0/24", "selected": 1},
+                        "10.0.0.0/8": {"value": "10.0.0.0/8", "selected": 1},
+                    },
+                    "categories": [],
+                    "description": "Test alias",
+                }
+            },
+        )
+    )
+    alias = client.firewall.get_alias("alias-uuid")
+    assert alias.type == "network"
+    assert alias.proto == ""
+    assert alias.interface == ""
+    assert alias.content == "192.168.1.0/24\n10.0.0.0/8"
+    assert alias.categories == ""
+    assert alias.description == "Test alias"
+
+
+def test_get_alias_single_content_entry(
+    client: OPNsenseClient, mock_api: respx.MockRouter
+) -> None:
+    mock_api.get("/api/firewall/alias/get_item/alias-uuid").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "alias": {
+                    "name": "single",
+                    "type": {
+                        "host": {"value": "Host(s)", "selected": 1},
+                    },
+                    "content": {
+                        "192.30.252.0/22": {"value": "192.30.252.0/22", "selected": 1},
+                    },
+                    "categories": [],
+                }
+            },
+        )
+    )
+    alias = client.firewall.get_alias("alias-uuid")
+    assert alias.type == "host"
+    assert alias.content == "192.30.252.0/22"
+
+
 def test_search_aliases(client: OPNsenseClient, mock_api: respx.MockRouter) -> None:
     mock_api.post("/api/firewall/alias/search_item").mock(
         return_value=httpx.Response(

--- a/tests/unit/modules/core/test_firewall.py
+++ b/tests/unit/modules/core/test_firewall.py
@@ -3,6 +3,13 @@ import pytest
 import respx
 
 from opnsense_py import OPNsenseClient
+from opnsense_py.models.firewall import (
+    FilterRule,
+    FirewallAlias,
+    NPTRule,
+    OneToOneRule,
+    SNatRule,
+)
 
 
 def test_savepoint_yields_revision(
@@ -85,6 +92,25 @@ def test_toggle_filter_rule_enabled(
     )
     client.firewall.toggle_filter_rule("rule-uuid", enabled=True)
     assert route.called
+
+
+@pytest.mark.parametrize(
+    "model_cls",
+    [FilterRule, FirewallAlias, SNatRule, NPTRule, OneToOneRule],
+)
+def test_categories_empty_list_coerced_to_empty_string(model_cls: type) -> None:
+    """OPNsense returns categories: [] for resources with no category assigned."""
+    instance = model_cls.model_validate({"categories": []})
+    assert instance.categories == ""
+
+
+@pytest.mark.parametrize(
+    "model_cls",
+    [FilterRule, FirewallAlias, SNatRule, NPTRule, OneToOneRule],
+)
+def test_categories_string_value_unchanged(model_cls: type) -> None:
+    instance = model_cls.model_validate({"categories": "some-uuid"})
+    assert instance.categories == "some-uuid"
 
 
 def test_search_aliases(client: OPNsenseClient, mock_api: respx.MockRouter) -> None:


### PR DESCRIPTION
## Summary

- `_extract_selected` in `models/base.py` previously returned only the **first** selected key from a form-data dict — which silently truncated multi-select fields like `content` on a `FirewallAlias` (e.g. an alias with multiple IPs would only keep the first one)
- Fixed by collecting **all** selected keys and joining with `\n`, which matches the POST payload format OPNsense already expects
- Single-select fields (`type`, `proto`, `interface`) are unaffected — one key still yields a plain string

Closes #4

> **Note:** this branch is based on `fix/categories-empty-list` (#7) since issue #4's fix depends on the `_normalize_edit_form` validator introduced there. Both can be merged in sequence or this one rebased onto main after that PR lands.

## Test plan

- [x] `test_get_alias_parses_edit_form_response` — full form-data response round-trip (multi-select content, single-select type/proto/interface, `categories: []`)
- [x] `test_get_alias_single_content_entry` — single-entry content doesn't get spurious separator
- [x] Full test suite passes (`uv run pytest` — 89/89)
- [x] `ruff check` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)